### PR TITLE
Bump dependency versions

### DIFF
--- a/.clj-kondo/imports/io.pedestal/pedestal.error/hooks/io/pedestal/interceptor/error.clj_kondo
+++ b/.clj-kondo/imports/io.pedestal/pedestal.error/hooks/io/pedestal/interceptor/error.clj_kondo
@@ -17,7 +17,7 @@
   to (fn [ctx ex] (case [ctx ex] match-forms)) keeping spirit of
   error-dispatch per clj-kondo examples."
   [{:keys [:node]}]
-  (let [[binding-vec & match-forms] (rest (:children node))]
+  (let [[_ binding-vec & match-forms] (:children node)]
     (when-not (= 2 (count (:children binding-vec)))
       (throw (ex-info "error-dispatch only takes ctx and ex." {})))
     {:node (api/list-node [(api/token-node 'fn)

--- a/.clj-kondo/imports/taoensso/encore/config.edn
+++ b/.clj-kondo/imports/taoensso/encore/config.edn
@@ -3,4 +3,5 @@
   {taoensso.encore/defalias    taoensso.encore-hooks/defalias
    taoensso.encore/defaliases  taoensso.encore-hooks/defaliases
    taoensso.encore/defn-cached taoensso.encore-hooks/defn-cached
-   taoensso.encore/defonce     taoensso.encore-hooks/defonce}}}
+   taoensso.encore/defonce     taoensso.encore-hooks/defonce
+   taoensso.encore/def*        taoensso.encore-hooks/def*}}}

--- a/.clj-kondo/imports/taoensso/encore/taoensso/encore_hooks.clj
+++ b/.clj-kondo/imports/taoensso/encore/taoensso/encore_hooks.clj
@@ -64,8 +64,8 @@
              binding-vec
              body))))}))
 
-(defn defonce
-  [{:keys [node]}]
+(defn -def-impl
+  [{:keys [node]} core-macro-sym]
   ;; args = [sym doc-string? attr-map? init-expr]
   (let [[sym & args] (rest (:children node))
         [doc-string args]    (if (and (hooks/string-node? (first args)) (next args)) [(hooks/sexpr (first args)) (next  args)] [nil        args])
@@ -73,10 +73,16 @@
 
         attr-map (if doc-string (assoc attr-map :doc doc-string) attr-map)
         sym+meta (if attr-map (with-meta sym attr-map) sym)
+
         rewritten
         (hooks/list-node
-          [(hooks/token-node 'clojure.core/defonce)
+          [(hooks/token-node core-macro-sym)
            sym+meta
            init-expr])]
 
+    #_(println "old node:" node)
+    #_(println "new node:" rewritten)
     {:node rewritten}))
+
+(defn def*    [arg] (-def-impl arg 'def))
+(defn defonce [arg] (-def-impl arg 'clojure.core/defonce))

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,11 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: lein deps

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: lein deps
       - name: Linter Check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
-      - uses: actions/checkout@v4
       - name: Install dependencies
         run: lein deps
       - name: Run unit and integration tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 16
-        uses: actions/setup-java@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
-          java-version: '16'
+          distribution: 'temurin'
+          java-version: '17'
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: lein deps
       - name: Run unit and integration tests

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ pom.xml.asc
 /service-component.iml
 /.lsp/.cache/
 /.clj-kondo/.cache/
+/.clj-kondo/imports/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,19 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions
 of [keepachangelog.com](http://keepachangelog.com/).
 
-## [Unreleased]
+## 5.4.2 - 2025-12-25
+
+### Changed
+- **Major Pedestal Upgrade**: Migrated from Pedestal 0.7.x to 0.8.x, adopting the new connector-based API.
+    - Refactored `service-component.core` to use `io.pedestal.connector` and `io.pedestal.http.jetty`, replacing the deprecated `io.pedestal.http` API.
+    - Migrated interceptors and test utilities to use modern namespaces like `io.pedestal.connector` and `io.pedestal.service.interceptors`.
+- **Error Handling**: Enhanced the error handler interceptor to guarantee JSON responses with the correct `Content-Type` header, ensuring consistent API error output.
+
+### Dependencies
+- Upgraded Pedestal to `0.8.1`.
+- Upgraded Clojure to `1.12.4`.
+- Upgraded Integrant to `1.0.1`.
+- Updated various development and test dependencies to their latest versions.
 
 ## 4.4.2 - 2025-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@ of [keepachangelog.com](http://keepachangelog.com/).
 ## 5.4.2 - 2025-12-25
 
 ### Changed
+
 - **Major Pedestal Upgrade**: Migrated from Pedestal 0.7.x to 0.8.x, adopting the new connector-based API.
-    - Refactored `service-component.core` to use `io.pedestal.connector` and `io.pedestal.http.jetty`, replacing the deprecated `io.pedestal.http` API.
-    - Migrated interceptors and test utilities to use modern namespaces like `io.pedestal.connector` and `io.pedestal.service.interceptors`.
-- **Error Handling**: Enhanced the error handler interceptor to guarantee JSON responses with the correct `Content-Type` header, ensuring consistent API error output.
+    - Refactored `service-component.core` to use `io.pedestal.connector` and `io.pedestal.http.jetty`, replacing the
+      deprecated `io.pedestal.http` API.
+    - Updated interceptors and test utilities to use modern namespaces like `io.pedestal.connector` and
+      `io.pedestal.service.interceptors`.
+- **Interceptors**: The default set of interceptors was updated to align with the new Pedestal 0.8 architecture and
+  improve error handling.
 
 ### Dependencies
+
 - Upgraded Pedestal to `0.8.1`.
 - Upgraded Clojure to `1.12.4`.
 - Upgraded Integrant to `1.0.1`.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/service-component "4.4.2"
+(defproject net.clojars.macielti/service-component "5.4.2"
 
   :description "Service Component is a Pedestal service Integrant component"
 

--- a/project.clj
+++ b/project.clj
@@ -7,27 +7,27 @@
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url  "https://www.eclipse.org/legal/epl-2.0/"}
 
-  :dependencies [[org.clojure/clojure "1.12.1"]
-                 [io.pedestal/pedestal.service "0.7.2"]
-                 [io.pedestal/pedestal.jetty "0.7.2"]
-                 [io.pedestal/pedestal.error "0.7.2"]
+  :dependencies [[org.clojure/clojure "1.12.4"]
+                 [io.pedestal/pedestal.service "0.8.1"]
+                 [io.pedestal/pedestal.jetty "0.8.1"]
+                 [io.pedestal/pedestal.error "0.8.1"]
                  [org.clojure/tools.logging "1.3.0"]
                  [clj-commons/iapetos "0.1.14"]             ;;TODO Use prometheus-component dependency instead of iapetos
                  [siili/humanize "0.1.1"]
-                 [integrant "0.13.1"]]
+                 [integrant "1.0.1"]]
 
   :profiles {:dev {:resource-paths ^:replace ["test/resources"]
 
                    :test-paths     ^:replace ["test/unit" "test/integration" "test/helpers"]
 
                    :plugins        [[lein-cloverage "1.2.4"]
-                                    [com.github.clojure-lsp/lein-clojure-lsp "2.0.9"]
+                                    [com.github.clojure-lsp/lein-clojure-lsp "2.0.13"]
                                     [com.github.liquidz/antq "RELEASE"]]
 
                    :dependencies   [[net.clojars.macielti/common-clj "43.74.74"]
                                     [prismatic/schema "1.4.1"]
-                                    [nubank/matcher-combinators "3.9.1"]
-                                    [com.taoensso/timbre "6.7.1"]
+                                    [nubank/matcher-combinators "3.9.2"]
+                                    [com.taoensso/timbre "6.8.0"]
                                     [hashp "0.2.2"]]
 
                    :injections     [(require 'hashp.core)]

--- a/src/service_component/core.clj
+++ b/src/service_component/core.clj
@@ -1,23 +1,27 @@
 (ns service-component.core
   (:require [clojure.tools.logging :as log]
             [integrant.core :as ig]
-            [io.pedestal.http :as http]
+            [io.pedestal.connector]
+            [io.pedestal.http.jetty :as jetty]
             [service-component.interceptors :as io.interceptors]))
 
 (defmethod ig/init-key ::service
   [_ {:keys [components]}]
   (log/info :starting ::service)
-  (http/start (-> {::http/routes          (:routes components)
-                   ::http/allowed-origins (constantly true)
-                   ::http/host            (-> components :config :service :host)
-                   ::http/port            (-> components :config :service :port)
-                   ::http/type            :jetty
-                   ::http/join?           false}
-                  http/default-interceptors
-                  (update ::http/interceptors concat (io.interceptors/default-interceptors components))
-                  http/create-server)))
+  (let [connector (-> {:host            (-> components :config :service :host)
+                       :port            (-> components :config :service :port)
+                       :type            :jetty
+                       :router          :sawtooth
+                       :initial-context {}
+                       :join?           false}
+                      (io.pedestal.connector/with-default-interceptors :allowed-origins (constantly true))
+                      (io.pedestal.connector/with-interceptors [io.interceptors/error-handler-interceptor
+                                                                (io.interceptors/components-interceptor components)])
+                      (io.pedestal.connector/with-routes (:routes components))
+                      (jetty/create-connector {}))]
+    (io.pedestal.connector/start! connector)))
 
 (defmethod ig/halt-key! ::service
   [_ service]
   (log/info :stopping ::service)
-  (http/stop service))
+  (io.pedestal.connector/stop! service))

--- a/src/service_component/interceptors.clj
+++ b/src/service_component/interceptors.clj
@@ -3,10 +3,8 @@
             [clojure.tools.logging :as log]
             [humanize.schema :as h]
             [iapetos.core :as prometheus]
-            [io.pedestal.http.body-params :as body-params]
             [io.pedestal.interceptor :as pedestal.interceptor]
             [io.pedestal.interceptor.error :as error]
-            [io.pedestal.service.interceptors :as pedestal.service.interceptors]
             [schema.coerce :as coerce]
             [schema.core :as s]
             [schema.utils]
@@ -37,12 +35,6 @@
    {:name  ::components-interceptor
     :enter (fn [context]
              (assoc-in context [:request :components] system-components))}))
-
-(defn default-interceptors [components]
-  [(body-params/body-params)
-   (components-interceptor components)
-   pedestal.service.interceptors/json-body
-   error-handler-interceptor])
 
 (defn schema-body-in-interceptor [schema]
   (pedestal.interceptor/interceptor {:name  ::schema-body-in-interceptor


### PR DESCRIPTION
### Changed

- **Major Pedestal Upgrade**: Migrated from Pedestal 0.7.x to 0.8.x, adopting the new connector-based API.
    - Refactored `service-component.core` to use `io.pedestal.connector` and `io.pedestal.http.jetty`, replacing the
      deprecated `io.pedestal.http` API.
    - Updated interceptors and test utilities to use modern namespaces like `io.pedestal.connector` and
      `io.pedestal.service.interceptors`.
- **Interceptors**: The default set of interceptors was updated to align with the new Pedestal 0.8 architecture and
  improve error handling.

### Dependencies

- Upgraded Pedestal to `0.8.1`.
- Upgraded Clojure to `1.12.4`.
- Upgraded Integrant to `1.0.1`.
- Updated various development and test dependencies to their latest versions.