### PR TITLE
Improving compatibility with `EqSchema` for Schema Coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions
 of [keepachangelog.com](http://keepachangelog.com/).
 
+## 7.4.3 - 2026-01-11
+
+### Changed
+
+- Breaking Change: Error handling for request body validation has been updated.
+    - The error code for schema validation failures is now invalid-request-body-payload.
+    - Error messages for invalid request bodies are improved for clarity.
+    - Error details in responses are now consistently stringified.
+- Schema Coercion: String values in JSON request bodies are now automatically coerced to keywords when the schema
+  expects a keyword, improving compatibility with EqSchema.
+
 ## 6.4.3 - 2026-01-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ of [keepachangelog.com](http://keepachangelog.com/).
 ### Changed
 
 - Breaking Change: Error handling for request body validation has been updated.
-    - The error code for schema validation failures is now invalid-request-body-payload.
+    - The error code for schema validation failures is now `"invalid-request-body-payload"`.
     - Error messages for invalid request bodies are improved for clarity.
     - Error details in responses are now consistently stringified.
 - Schema Coercion: String values in JSON request bodies are now automatically coerced to keywords when the schema
-  expects a keyword, improving compatibility with EqSchema.
+  expects a keyword, improving compatibility with `EqSchema`.
 
 ## 6.4.3 - 2026-01-02
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/service-component "6.4.3"
+(defproject net.clojars.macielti/service-component "7.4.3"
 
   :description "Service Component is a Pedestal service Integrant component"
 

--- a/test/integration/service_component_test.clj
+++ b/test/integration/service_component_test.clj
@@ -56,14 +56,14 @@
       (reset! test-state nil)
       (is (match? {:status  422
                    :headers {"Content-Type" "application/json;charset=UTF-8"}
-                   :body    "{\"error\":\"invalid-schema-in\",\"message\":\"The system detected that the received data is invalid\",\"detail\":{\"test\":\"Missing required key\"}}"}
+                   :body    "{\"error\":\"invalid-request-body-payload\",\"message\":\"The system detected that the received data is invalid.\",\"detail\":\"{:test \\\"Missing required key\\\"}\"}"}
                   (test/response-for connector :post "/schema-validation-interceptor-test"
                                      :headers {:content-type "application/json"}
                                      :body (json/encode {}))))
 
       (is (match? {:status  422
                    :headers {"Content-Type" "application/json;charset=UTF-8"}
-                   :body    "{\"error\":\"invalid-schema-in\",\"message\":\"The system detected that the received data is invalid\",\"detail\":{\"hello\":\"Invalid key.\",\"test\":\"Missing required key\"}}"}
+                   :body    "{\"error\":\"invalid-request-body-payload\",\"message\":\"The system detected that the received data is invalid.\",\"detail\":\"{:hello \\\"Invalid key.\\\", :test \\\"Missing required key\\\"}\"}"}
                   (test/response-for connector :post "/schema-validation-interceptor-test"
                                      :headers {:content-type "application/json"}
                                      :body (json/encode {:hello :world}))))
@@ -71,7 +71,7 @@
       (reset! test-state nil)
       (is (match? {:status  422
                    :headers {"Content-Type" "application/json;charset=UTF-8"}
-                   :body    "{\"error\":\"invalid-schema-in\",\"message\":\"The system detected that the received data is invalid\",\"detail\":\"The value must be a map, but was '' instead.\"}"}
+                   :body    "{\"error\":\"invalid-request-body-payload\",\"message\":\"The system detected that the received data is invalid.\",\"detail\":\"The value must be a map, but was '' instead.\"}"}
                   (test/response-for connector :post "/schema-validation-interceptor-test")))
 
       (reset! test-state nil)


### PR DESCRIPTION
### Changed

- Breaking Change: Error handling for request body validation has been updated.
    - The error code for schema validation failures is now invalid-request-body-payload.
    - Error messages for invalid request bodies are improved for clarity.
    - Error details in responses are now consistently stringified.
- Schema Coercion: String values in JSON request bodies are now automatically coerced to keywords when the schema
  expects a keyword, improving compatibility with EqSchema.