### PR TITLE
Release 0.3.7: add configurable idle timeout and CORS allowed origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions
 of [keepachangelog.com](http://keepachangelog.com/).
 
+## 0.3.7 - 2026-03-08
+
+### Added
+
+- Configurable Jetty idle timeout via `:idle-timeout-ms` option (defaults to `30000` ms).
+- Configurable CORS allowed origins via `:allowed-origins` option (defaults to allowing all origins).
+- Documentation for service configuration options in README.
+
+### Changed
+
+- Upgraded `common-clj` dependency from `46.0.0` to `46.1.4`.
+- Upgraded `lein-clojure-lsp` plugin from `2.0.13` to `2.0.14`.
+
 ## 0.3.6 - 2026-03-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,6 +15,30 @@ dependencies to your project:
   [io.pedestal/pedestal.error "0.8.1"]
 ```
 
+## Configuration
+
+The service component accepts configuration through the `:service` key in your config map. The following options are available:
+
+| Key                 | Type                | Required | Default        | Description                                                                          |
+|---------------------|---------------------|----------|----------------|--------------------------------------------------------------------------------------|
+| `:host`             | String              | Yes      | —              | The host address to bind the server to (e.g., `"0.0.0.0"`).                         |
+| `:port`             | Integer             | Yes      | —              | The port number to listen on (e.g., `8080`).                                         |
+| `:idle-timeout-ms`  | Integer             | No       | `30000`        | Jetty idle timeout in milliseconds. Connections idle beyond this duration are closed. |
+| `:allowed-origins`  | Collection\<String> | No       | Allow all origins | A collection of allowed origin strings for CORS. When provided, only the specified origins are permitted. When omitted or empty, all origins are allowed. |
+
+### Example
+
+```clojure
+{:service {:host            "0.0.0.0"
+           :port            8080
+           :idle-timeout-ms 60000                                     ;; 60 seconds
+           :allowed-origins ["https://example.com" "https://app.example.com"]}}
+```
+
+> **Note:** If `:idle-timeout-ms` is not provided, a default of **30 seconds** (`30000` ms) is applied to prevent long-running or stalled requests from tying up server threads indefinitely.
+
+> **Note:** If `:allowed-origins` is not provided or is empty, the server will accept requests from **any origin**. In production, it is recommended to explicitly list trusted origins to prevent unwanted cross-origin access.
+
 ## License
 
 Copyright © 2024 Bruno do Nascimento Maciel

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/service "0.3.6"
+(defproject net.clojars.macielti/service "0.3.7"
 
   :description "Service is a Pedestal service Integrant component"
 
@@ -8,7 +8,7 @@
             :url  "https://www.eclipse.org/legal/epl-2.0/"}
 
   :dependencies [[org.clojure/clojure "1.12.4"]
-                 [net.clojars.macielti/common-clj "46.0.0"]
+                 [net.clojars.macielti/common-clj "46.1.4"]
                  [io.pedestal/pedestal.service "0.8.1"]
                  [com.vodori/schema-conformer "0.1.2"]
                  [io.pedestal/pedestal.jetty "0.8.1"]
@@ -23,13 +23,14 @@
                    :test-paths     ^:replace ["test/unit" "test/integration" "test/helpers"]
 
                    :plugins        [[lein-cloverage "1.2.4"]
-                                    [com.github.clojure-lsp/lein-clojure-lsp "2.0.13"]
+                                    [com.github.clojure-lsp/lein-clojure-lsp "2.0.14"]
                                     [com.github.liquidz/antq "RELEASE"]]
 
                    :dependencies   [[prismatic/schema "1.4.1"]
                                     [nubank/matcher-combinators "3.10.0"]
                                     [com.taoensso/timbre "6.8.0"]
-                                    [hashp "0.2.2"]]
+                                    [hashp "0.2.2"]
+                                    [clj-http "3.13.1"]]
 
                    :injections     [(require 'hashp.core)]
 

--- a/src/service/component.clj
+++ b/src/service/component.clj
@@ -5,20 +5,39 @@
             [io.pedestal.http.jetty :as jetty]
             [service.interceptors :as io.interceptors]))
 
+;; Default Jetty idle timeout in milliseconds.
+;; Consumers can override this by setting :idle-timeout-ms in their service config.
+;; e.g., {:service {:host "0.0.0.0" :port 8080 :idle-timeout-ms 60000}}
+(def ^:private default-idle-timeout-ms 30000)
+
+(def ^:private allow-all-origins (constantly true))
+
+(defn ^:private allowed-origins
+  "Returns the allowed-origins value for Pedestal.
+  When a collection of origin strings is provided, returns it as a set.
+  Otherwise, allows all origins."
+  [origins]
+  (if (not-empty origins)
+    (set origins)
+    allow-all-origins))
+
 (defmethod ig/init-key ::service
   [_ {:keys [components]}]
   (log/info :starting ::service)
-  (let [connector (-> {:host            (-> components :config :service :host)
+  (let [idle-timeout (or (-> components :config :service :idle-timeout-ms)
+                         default-idle-timeout-ms)
+        allowed-origins' (-> components :config :service :allowed-origins)
+        connector (-> {:host            (-> components :config :service :host)
                        :port            (-> components :config :service :port)
                        :type            :jetty
                        :router          :sawtooth
                        :initial-context {}
                        :join?           false}
-                      (io.pedestal.connector/with-default-interceptors :allowed-origins (constantly true))
+                      (io.pedestal.connector/with-default-interceptors :allowed-origins (allowed-origins allowed-origins'))
                       (io.pedestal.connector/with-interceptors [io.interceptors/error-handler-interceptor
                                                                 (io.interceptors/components-interceptor components)])
                       (io.pedestal.connector/with-routes (:routes components))
-                      (jetty/create-connector {}))]
+                      (jetty/create-connector {:io.pedestal.http.jetty/idle-timeout idle-timeout}))]
     (io.pedestal.connector/start! connector)))
 
 (defmethod ig/halt-key! ::service

--- a/src/service/component.clj
+++ b/src/service/component.clj
@@ -5,9 +5,6 @@
             [io.pedestal.http.jetty :as jetty]
             [service.interceptors :as io.interceptors]))
 
-;; Default Jetty idle timeout in milliseconds.
-;; Consumers can override this by setting :idle-timeout-ms in their service config.
-;; e.g., {:service {:host "0.0.0.0" :port 8080 :idle-timeout-ms 60000}}
 (def ^:private default-idle-timeout-ms 30000)
 
 (def ^:private allow-all-origins (constantly true))

--- a/src/service/interceptors.clj
+++ b/src/service/interceptors.clj
@@ -6,7 +6,6 @@
             [iapetos.core :as prometheus]
             [io.pedestal.interceptor :as pedestal.interceptor]
             [schema.coerce :as coerce]
-            [schema.core :as s]
             [schema.core]
             [schema.utils]
             [service.error :as common-error])
@@ -78,7 +77,7 @@
 
 (def ^:private coercions
   {LocalDate (fn [input] (LocalDate/parse input))
-   s/Uuid    (fn [input] (parse-uuid input))})
+   schema.core/Uuid    (fn [input] (parse-uuid input))})
 
 (defn ^:private coercions-matcher
   [schema]

--- a/test/integration/cors_test.clj
+++ b/test/integration/cors_test.clj
@@ -1,0 +1,65 @@
+(ns cors-test
+  (:require [clj-http.client :as http]
+            [clojure.test :refer [is testing]]
+            [common-clj.integrant-components.config :as component.config]
+            [common-clj.integrant-components.prometheus :as component.prometheus]
+            [common-clj.integrant-components.routes :as component.routes]
+            [integrant.core :as ig]
+            [io.pedestal.service.interceptors :as pedestal.service.interceptors]
+            [matcher-combinators.test :refer [match?]]
+            [schema.test :as s]
+            [service.component :as component.service]
+            [service.interceptors :as interceptors]))
+
+(def routes [["/test" :get [interceptors/http-request-in-handle-timing-interceptor
+                            pedestal.service.interceptors/json-body
+                            (fn [{{:keys [config]} :components}]
+                              {:status 200
+                               :body   config})]
+              :route-name :test]])
+
+(def system-components
+  {::component.config/config         {:path "test/resources/config.example.edn"
+                                      :env  :test}
+   ::component.routes/routes         {:routes routes}
+   ::component.prometheus/prometheus {:metrics []}
+   ::component.service/service       {:components {:config     (ig/ref ::component.config/config)
+                                                   :prometheus (ig/ref ::component.prometheus/prometheus)
+                                                   :routes     (ig/ref ::component.routes/routes)}}})
+
+(s/deftest allowed-origins-allow-all-test
+  (testing "When no allowed-origins is configured, all origins are permitted"
+    (let [system (ig/init system-components)]
+
+      (is (match? {:status  200
+                   :headers {"Access-Control-Allow-Origin" "https://any-origin.com"}}
+                  (http/get "http://localhost:8080/test"
+                            {:headers          {"Origin"        "https://any-origin.com"
+                                                "authorization" "Bearer test-token"}
+                             :throw-exceptions false})))
+
+      (ig/halt! system))))
+
+(s/deftest allowed-origins-restricted-test
+  (testing "When allowed-origins is configured, only specified origins are permitted"
+    (let [system (ig/init (assoc-in system-components
+                                    [::component.config/config :overrides]
+                                    {:service {:host            "0.0.0.0"
+                                               :port            8080
+                                               :allowed-origins ["https://allowed.com" "https://trusted.com"]}}))]
+
+      (is (match? {:status  200
+                   :headers {"Access-Control-Allow-Origin" "https://allowed.com"}}
+                  (http/get "http://localhost:8080/test"
+                            {:headers          {"Origin"        "https://allowed.com"
+                                                "authorization" "Bearer test-token"}
+                             :throw-exceptions false})))
+
+      (is (match? {:status  403
+                   :headers (fn [headers] (nil? (get headers "Access-Control-Allow-Origin")))}
+                  (http/get "http://localhost:8080/test"
+                            {:headers          {"Origin"        "https://not-allowed.com"
+                                                "authorization" "Bearer test-token"}
+                             :throw-exceptions false})))
+
+      (ig/halt! system))))

--- a/test/integration/idle_timeout_test.clj
+++ b/test/integration/idle_timeout_test.clj
@@ -1,0 +1,154 @@
+(ns idle-timeout-test
+  (:require [clj-http.client :as http]
+            [clojure.test :refer [is testing]]
+            [common-clj.integrant-components.config :as component.config]
+            [common-clj.integrant-components.prometheus :as component.prometheus]
+            [common-clj.integrant-components.routes :as component.routes]
+            [integrant.core :as ig]
+            [io.pedestal.service.interceptors :as pedestal.service.interceptors]
+            [matcher-combinators.test :refer [match?]]
+            [schema.test :as s]
+            [service.component :as component.service]
+            [service.interceptors :as interceptors])
+  (:import (java.net Socket SocketTimeoutException)
+           (java.io BufferedReader InputStreamReader PrintWriter)))
+
+(def routes [["/test" :get [interceptors/http-request-in-handle-timing-interceptor
+                            pedestal.service.interceptors/json-body
+                            (fn [{{:keys [config]} :components}]
+                              {:status 200
+                               :body   config})]
+              :route-name :test]
+             ["/slow" :get [pedestal.service.interceptors/json-body
+                            (fn [_]
+                              (Thread/sleep 2000)
+                              {:status 200
+                               :body   {:message "slow response"}})]
+              :route-name :slow]])
+
+(def system-components
+  {::component.config/config         {:path "test/resources/config.example.edn"
+                                      :env  :test}
+   ::component.routes/routes         {:routes routes}
+   ::component.prometheus/prometheus {:metrics []}
+   ::component.service/service       {:components {:config     (ig/ref ::component.config/config)
+                                                   :prometheus (ig/ref ::component.prometheus/prometheus)
+                                                   :routes     (ig/ref ::component.routes/routes)}}})
+
+(defn- create-socket-connection
+  "Creates a raw socket connection to test idle timeout behavior."
+  [port]
+  (Socket. "localhost" (int port)))
+
+(defn- send-partial-request
+  "Sends a partial HTTP request and waits to trigger idle timeout."
+  [socket wait-ms]
+  (let [^java.io.OutputStream os (.getOutputStream socket)
+        out (PrintWriter. os true)]
+    (.println out "GET /test HTTP/1.1")
+    (.println out "Host: localhost")
+    ;; Don't send the final blank line to keep connection open
+    (.flush out)
+    (Thread/sleep (long wait-ms))))
+
+(s/deftest default-idle-timeout-test
+  (testing "The default idle timeout of 30000ms is applied when not configured"
+    (let [system (ig/init system-components)]
+
+      ;; Verify normal requests work
+      (is (match? {:status 200}
+                  (http/get "http://localhost:8080/test"
+                            {:headers          {"authorization" "Bearer test-token"}
+                             :throw-exceptions false})))
+
+      ;; Test that connection times out after default idle timeout
+      (testing "Connection should timeout after being idle"
+        (let [socket (create-socket-connection 8080)]
+          (try
+            ;; Set socket read timeout slightly longer than expected idle timeout
+            (.setSoTimeout socket 35000)
+
+            ;; Send partial request and wait
+            (send-partial-request socket 31000)
+
+            ;; Try to read response - should time out or connection closed
+            (let [in (BufferedReader. (InputStreamReader. (.getInputStream socket)))
+                  response (try
+                             (.readLine in)
+                             (catch SocketTimeoutException _
+                               :socket-timeout)
+                             (catch Exception e
+                               (if (or (.contains (.getMessage e) "Connection reset")
+                                       (.contains (.getMessage e) "Socket closed"))
+                                 :connection-closed
+                                 (throw e))))]
+              (is (or (= :socket-timeout response)
+                      (= :connection-closed response)
+                      (nil? response))
+                  "Connection should be closed after idle timeout"))
+            (finally
+              (.close socket)))))
+
+      (ig/halt! system))))
+
+(s/deftest custom-idle-timeout-test
+  (testing "A custom idle timeout can be configured via :idle-timeout-ms"
+    (let [system (ig/init (assoc-in system-components
+                                    [::component.config/config :overrides]
+                                    {:service {:host            "0.0.0.0"
+                                               :port            8080
+                                               :idle-timeout-ms 5000}}))]
+
+      ;; Verify normal requests work
+      (is (match? {:status 200}
+                  (http/get "http://localhost:8080/test"
+                            {:headers          {"authorization" "Bearer test-token"}
+                             :throw-exceptions false})))
+
+      ;; Test that connection times out after custom idle timeout
+      (testing "Connection should timeout after custom idle timeout period"
+        (let [socket (create-socket-connection 8080)]
+          (try
+            ;; Set socket read timeout slightly longer than expected idle timeout
+            (.setSoTimeout socket 10000)
+
+            ;; Send partial request and wait for longer than custom timeout
+            (send-partial-request socket 6000)
+
+            ;; Try to read response - should time out or connection closed
+            (let [in (BufferedReader. (InputStreamReader. (.getInputStream socket)))
+                  response (try
+                             (.readLine in)
+                             (catch SocketTimeoutException _
+                               :socket-timeout)
+                             (catch Exception e
+                               (if (or (.contains (.getMessage e) "Connection reset")
+                                       (.contains (.getMessage e) "Socket closed"))
+                                 :connection-closed
+                                 (throw e))))]
+              (is (or (= :socket-timeout response)
+                      (= :connection-closed response)
+                      (nil? response))
+                  "Connection should be closed after custom idle timeout"))
+            (finally
+              (.close socket)))))
+
+      (ig/halt! system))))
+
+(s/deftest idle-timeout-does-not-affect-active-connections-test
+  (testing "Idle timeout does not affect active connections that are processing requests"
+    (let [system (ig/init (assoc-in system-components
+                                    [::component.config/config :overrides]
+                                    {:service {:host            "0.0.0.0"
+                                               :port            8080
+                                               :idle-timeout-ms 5000}}))]
+
+      ;; A slow endpoint that takes 2 seconds should complete successfully
+      ;; even though it's less than the idle timeout
+      (is (match? {:status 200
+                   :body   "{\"message\":\"slow response\"}"}
+                  (http/get "http://localhost:8080/slow"
+                            {:throw-exceptions false
+                             :socket-timeout   10000})))
+
+      (ig/halt! system))))


### PR DESCRIPTION
### Added

- Configurable Jetty idle timeout via `:idle-timeout-ms` option (defaults to `30000` ms).
- Configurable CORS allowed origins via `:allowed-origins` option (defaults to allowing all origins).
- Documentation for service configuration options in README.

### Changed

- Upgraded `common-clj` dependency from `46.0.0` to `46.1.4`.
- Upgraded `lein-clojure-lsp` plugin from `2.0.13` to `2.0.14`.